### PR TITLE
Fix: Messaging in wxt-core/messaging

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,24 @@
+name: Release Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: https://npm.pkg.github.com/
+      - name: Install dependencies and build 🔧
+        run: npm ci && npm run build
+      - name: Publish package on Github 📦
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "webext-redux",
+  "name": "@testsigmainc/webext-redux",
   "version": "4.0.0",
   "description": "A set of utilities for building Redux applications in Web Extensions.",
   "main": "lib/index.js",
@@ -15,11 +15,14 @@
     "test-run": "mocha --require @babel/register --recursive",
     "test": "npm run lint && npm run test-run"
   },
+  "publishConfig": {
+    "@testsigmainc:registry": "https://npm.pkg.github.com"
+  },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tshaddix/webext-redux.git"
+    "url": "git+https://github.com/TestsigmaInc/webext-redux.git"
   },
-  "author": "Tyler Shaddix",
+  "author": "Testsigma",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/tshaddix/webext-redux/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@testsigmainc/webext-redux",
-  "version": "4.0.0",
+  "version": "1.0.0",
   "description": "A set of utilities for building Redux applications in Web Extensions.",
   "main": "lib/index.js",
   "typings": "./index.d.ts",

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -61,7 +61,7 @@ class Store {
 
     // We request the latest available state data to initialise our store
     this.browserAPI.runtime.sendMessage(
-      { type: FETCH_STATE_TYPE, channelName }, undefined, this.initializeStore
+      { type: FETCH_STATE_TYPE, channelName, timestamp: Date.now() }, undefined, this.initializeStore
     );
 
     this.deserializer = deserializer;
@@ -186,7 +186,8 @@ class Store {
         {
           type: DISPATCH_TYPE,
           channelName: this.channelName,
-          payload: data
+          payload: data,
+          timestamp: Date.now()
         }, null, (resp) => {
           if (!resp) {
             const error = this.browserAPI.runtime.lastError;

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -157,6 +157,7 @@ export default ({ channelName = defaultOpts.channelName } = defaultOpts) => {
           type: PATCH_STATE_TYPE,
           payload: diff,
           channelName, // Notifying what store is broadcasting the state changes
+          timestamp: Date.now(),
         });
       }
     };
@@ -169,6 +170,7 @@ export default ({ channelName = defaultOpts.channelName } = defaultOpts) => {
       type: STATE_TYPE,
       payload: currentState,
       channelName, // Notifying what store is broadcasting the state changes
+      timestamp: Date.now(),
     });
 
     /**
@@ -181,7 +183,8 @@ export default ({ channelName = defaultOpts.channelName } = defaultOpts) => {
       sendResponse({
         type: FETCH_STATE_TYPE,
         payload: state,
-      });
+        timestamp: Date.now(),
+      });xs
     });
 
     /**


### PR DESCRIPTION
Fix: Messaging in wxt-core/messaging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Outgoing state and dispatch messages now include timestamps for FETCH_STATE_TYPE, DISPATCH_TYPE, PATCH_STATE_TYPE, and STATE_TYPE.
- Chores
  - Added an automated “Release Package” GitHub Actions workflow to build and publish on release creation.
  - Updated package metadata: renamed package to @testsigmainc/webext-redux, version set to 1.0.0, repository moved to TestsigmaInc, and author updated.
  - Added publish configuration to use GitHub Packages for @testsigmainc scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->